### PR TITLE
Fix alpha in colors for Android

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -336,7 +336,7 @@ function hexColorForLayer(layer)
 function rgba2hex(r, g, b, a) {
     if (r > 255 || g > 255 || b > 255 || a > 255)
         throw "Invalid color component";
-    return (256 + r).toString(16).substr(1) +((1 << 24) + (g << 16) | (b << 8) | a).toString(16).substr(1);
+    return (256 + a).toString(16).substr(1) +((1 << 24) + (r << 16) | (g << 8) | b).toString(16).substr(1);
 }
 
 


### PR DESCRIPTION
The order of a color resource was being written as RRGGBBAA which is not correct for Android. The format should be AARRGGBB (https://developer.android.com/guide/topics/resources/more-resources.html#Color)
